### PR TITLE
add docker container and release

### DIFF
--- a/.github/workflows/docker-build-and-release.yml
+++ b/.github/workflows/docker-build-and-release.yml
@@ -1,0 +1,47 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-and-release.yml
+++ b/.github/workflows/docker-build-and-release.yml
@@ -6,9 +6,9 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
+#  pull_request: # only for demonstration in the pr
+#    branches:
+#      - 'master'
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.18 as build
+
+WORKDIR /go/src/bitbucket-cli
+COPY . .
+
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o /go/src/bitbucket-cli ./cmd/bitbucket-cli
+
+# Now copy it into our base image.
+FROM gcr.io/distroless/static-debian11
+COPY --from=build /go/src/bitbucket-cli /
+ENTRYPOINT ["/bitbucket-cli"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Commands:
   project
 ```
 
+# Docker container
+
+A docker container for this project can be obtained [here](https://github.com/swisscom/bitbucket-cli/pkgs/container/bitbucket-cli).
+
 ## Project
 
 ### List
@@ -152,3 +156,4 @@ Options:
 ```plain
 bitbucket-cli repo -k ABC -n some-repo security scan
 ```
+


### PR DESCRIPTION
Adds the possibility to release bitbucket-cli as a docker container.

Pushing a tag to github should be sufficient to create a release and push it to gh-packages. The run will be executed within github actions.

I executed a sample run on my fork here:
https://github.com/crasu/bitbucket-cli/actions/runs/3817763208/jobs/6494230624

The release page will look like this once you merge this:
https://github.com/crasu/bitbucket-cli/pkgs/container/bitbucket-cli